### PR TITLE
Fixing README.md examples (syntax and return errors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ use \Paggi\Paggi;
 use \Paggi\Charge;
 
 # First, set your API Key
-Paggi::setApiKey('B31DCE74-E768-43ED-86DA-85501612548F')
+Paggi::setApiKey('B31DCE74-E768-43ED-86DA-85501612548F');
 
 $charges = Charge::findAll();
-$charge  = $charges->result[0];
+$charge  = $charges['result'][0];
 
-$charge->cancel()
+$charge->cancel();
 ```
 
 TO see more details, visit our [API documentation](https://docs.paggi.com/docs)


### PR DESCRIPTION
$charges is not an object, so $charges->result[0] won't work. It must be treated as an array.
Fixed syntax errors at lines 24 and 29.