### PR TITLE
Fix double type of "static" on the function definition.

### DIFF
--- a/lib/Traits/Util.php
+++ b/lib/Traits/Util.php
@@ -54,7 +54,7 @@ trait Util
      *
      * @return array Array error
      */
-    static protected static function _getError($responseCurl)
+    static protected function _getError($responseCurl)
     {
         //The original message error from API
         $originalError = json_decode($responseCurl->rawResponse, true);


### PR DESCRIPTION
Fix a little, small, almost invisible, slightly inconvenient typing error.